### PR TITLE
Rewriten to use the domManip  callback

### DIFF
--- a/jquery.create.js
+++ b/jquery.create.js
@@ -1,6 +1,7 @@
 // written by eric hynds (erichynds.com)
+// updated to support text nodes by hans oksendahl (hansoksendahl.com)
 // http://www.erichynds.com/jquery/jquery-create-event/
-// version 1.4 - 10/12/2010
+// version 1.4.1 - 4/21/2011
 
 (function($, _domManip, _html){
 	var selectors = [], gen = [], guid = 0, old = {};
@@ -54,37 +55,51 @@
 		
 		// crawl through the html structure passed in looking for matching elements.
 		for( var i=0, len=nodes.length; i<len; i++ ){
-			node = $(nodes[i]);
+			// make sure we're only attempting to handle objects that jquery will treat
+			// as element references
+			if (
+				typeof nodes[i] == 'object' ||
+				(
+					typeof nodes[i] == 'string' &&
+					/</.test(nodes[i]) === true
+				)
+			) {
+				node = $(nodes[i]);
 			
-			if( !node.length ){
-				continue;
-			}
-			
-			(function walk( element ){
-				element = element || node[0].parentNode;
-				var cur = (element ? element.firstChild : node[0]);
-				
-				while(cur !== null){
-					for( var x=0; x<numSelectors; x++ ){
-						if( $(cur).is(selectors[x]) ){
-							if( !cur.id ){
-								cur.id = "jqcreateevt"+(++guid);
-								gen.push(cur.id); // remember that this ID was generated
-							}
-							
-							// remember this match
-							matches.push(cur.id);
-						}
-					}
-				
-					walk( cur );
-					cur = cur.nextSibling;
+				if( !node.length ){
+					continue;
 				}
-			})();
 			
-			// the html we started with, but with ids attached to elements
-			// bound with create.
-			html = html.add( node );
+				(function walk( element ){
+					element = element || node[0].parentNode;
+					var cur = (element ? element.firstChild : node[0]);
+				
+					while(cur !== null){
+						for( var x=0; x<numSelectors; x++ ){
+							if( $(cur).is(selectors[x]) ){
+								if( !cur.id ){
+									cur.id = "jqcreateevt"+(++guid);
+									gen.push(cur.id); // remember that this ID was generated
+								}
+							
+								// remember this match
+								matches.push(cur.id);
+							}
+						}
+				
+						walk( cur );
+						cur = cur.nextSibling;
+					}
+				})();
+			
+				// the html we started with, but with ids attached to elements
+				// bound with create.
+				html = html.add( node );
+			}
+			// if we can't create an element create a text node
+			else {
+				html = document.createTextNode(nodes[i]);
+			}
 		}
 		
 		// overwrite the passed in html with the new html

--- a/jquery.create.js
+++ b/jquery.create.js
@@ -1,7 +1,7 @@
 // based in pluggin by eric hynds (erichynds.com)
 // that was updated to support text nodes by hans oksendahl (hansoksendahl.com)
-// rewriten by Emilio Llamas (emilio.llamasalba@yahoo.com)
 // http://www.erichynds.com/jquery/jquery-create-event/
+// full rewrite by Emilio Llamas (yumok@yahoo.com)
 // version 1.5 - 5/10/2011
 
 (function($, _domManip, _html){
@@ -55,6 +55,18 @@
 							 	$.event.trigger("create", {}, elem);
 							}
 						}
+
+						$(elem).find(selectors[x]).each(function()
+						{
+							// double check to make sure the event hasn't already fired.
+							// can happen with wrap()
+							if( !$.data( this, "jqcreateevt") )
+							{
+								$.data(this, "jqcreateevt", true);
+							 	$.event.trigger("create", {}, this);
+							}
+
+						});
 
 				}
 			}

--- a/jquery.create.js
+++ b/jquery.create.js
@@ -25,6 +25,43 @@
 		}
 	};
 
+	// puede llamarse sobre los elementos creados con .innerHTML o otros metodos externos a jquery
+	$.fn.triggerCreateEvent = function ()
+	{
+		var $elem = this;
+
+		var numSelectors = selectors.length;
+//			console.log("checking selectors");
+		for( var x=0; x<numSelectors; x++ )
+		{
+//					console.log("checking selector:",selectors[x],elem);
+			if( $elem.is(selectors[x]) )
+			{
+				// double check to make sure the event hasn't already fired.
+				// can happen with wrap()
+				if( !$.data( $elem, "jqcreateevt") )
+				{
+					$.data($elem, "jqcreateevt", true);
+				 	$.event.trigger("create", {}, $elem);
+				}
+			}
+
+			$elem.find(selectors[x]).each(function()
+			{
+				// double check to make sure the event hasn't already fired.
+				// can happen with wrap()
+				if( !$.data( this, "jqcreateevt") )
+				{
+					$.data(this, "jqcreateevt", true);
+				 	$.event.trigger("create", {}, this);
+				}
+
+			});
+
+		}
+
+	}
+
 	// deal with 99% of DOM manip methods
 	$.fn.domManip = function( args, table, callback )
 	{
@@ -34,42 +71,50 @@
 
 		arguments[2] = function (elem)
 		{
+			// [this] es el objeto sobre el que se esta haciendo el append, html, etc...  y [elem] es el item 'creado'
+
 			//alert("stop callback");
 
+
+			// aplicamos el callback, para que termine de hacer el append o lo que sea y el selector funcione correctamente
+			//   (ej. si el selector es ".parentclass > .childclass", y estamos haciendo append de un nodo .childclass dentro
+			//     de un nodo .parentclass, no cumple el selector hasta que se hace efectivo el append)
 			var ret = true_callback.apply(this,arguments);
 
+
+			$(elem).triggerCreateEvent();
+
+/*
 			var numSelectors = selectors.length;
-			if( !$.data( elem, "jqcreateevt") )
+//			console.log("checking selectors");
+			for( var x=0; x<numSelectors; x++ )
 			{
-//				console.log("checking selectors");
-				for( var x=0; x<numSelectors; x++ )
-				{
-//						console.log("checking selector:",selectors[x],elem);
-						if( $(elem).is(selectors[x]) )
+//					console.log("checking selector:",selectors[x],elem);
+					if( $(elem).is(selectors[x]) )
+					{
+						// double check to make sure the event hasn't already fired.
+						// can happen with wrap()
+						if( !$.data( elem, "jqcreateevt") )
 						{
-							// double check to make sure the event hasn't already fired.
-							// can happen with wrap()
-							if( !$.data( elem, "jqcreateevt") )
-							{
-								$.data(elem, "jqcreateevt", true);
-							 	$.event.trigger("create", {}, elem);
-							}
+							$.data(elem, "jqcreateevt", true);
+						 	$.event.trigger("create", {}, elem);
+						}
+					}
+
+					$(elem).find(selectors[x]).each(function()
+					{
+						// double check to make sure the event hasn't already fired.
+						// can happen with wrap()
+						if( !$.data( this, "jqcreateevt") )
+						{
+							$.data(this, "jqcreateevt", true);
+						 	$.event.trigger("create", {}, this);
 						}
 
-						$(elem).find(selectors[x]).each(function()
-						{
-							// double check to make sure the event hasn't already fired.
-							// can happen with wrap()
-							if( !$.data( this, "jqcreateevt") )
-							{
-								$.data(this, "jqcreateevt", true);
-							 	$.event.trigger("create", {}, this);
-							}
+					});
 
-						});
-
-				}
 			}
+*/
 
 			return ret;
 		};

--- a/jquery.create.js
+++ b/jquery.create.js
@@ -1,7 +1,8 @@
-// written by eric hynds (erichynds.com)
-// updated to support text nodes by hans oksendahl (hansoksendahl.com)
+// based in pluggin by eric hynds (erichynds.com)
+// that was updated to support text nodes by hans oksendahl (hansoksendahl.com)
+// rewriten by Emilio Llamas (emilio.llamasalba@yahoo.com)
 // http://www.erichynds.com/jquery/jquery-create-event/
-// version 1.4.1 - 4/21/2011
+// version 1.5 - 5/10/2011
 
 (function($, _domManip, _html){
 	var selectors = [], gen = [], guid = 0, old = {};
@@ -10,7 +11,7 @@
 		add: function( data ){
 			selectors.push( data.selector );
 		},
-		
+
 		// won't fire in 1.4.2 http://dev.jquery.com/ticket/6202
 		remove: function( data ){
 			var len = selectors.length;
@@ -23,111 +24,66 @@
 			}
 		}
 	};
-	
+
 	// deal with 99% of DOM manip methods
-	$.fn.domManip = function( args, table, callback ){
-		
-		// if no create events are bound, just fire the original domManip method 
-		if( !selectors.length || $.isFunction(args[0]) ){
-			return _domManip.apply( this, arguments );
-		}
-		
-		return logic.call( this, _domManip, arguments );
+	$.fn.domManip = function( args, table, callback )
+	{
+		var true_callback = callback;
+
+		///////////////////////////////////////
+
+		arguments[2] = function (elem)
+		{
+			//alert("stop callback");
+
+			var ret = true_callback.apply(this,arguments);
+
+			var numSelectors = selectors.length;
+			if( !$.data( elem, "jqcreateevt") )
+			{
+//				console.log("checking selectors");
+				for( var x=0; x<numSelectors; x++ )
+				{
+//						console.log("checking selector:",selectors[x],elem);
+						if( $(elem).is(selectors[x]) )
+						{
+							// double check to make sure the event hasn't already fired.
+							// can happen with wrap()
+							if( !$.data( elem, "jqcreateevt") )
+							{
+								$.data(elem, "jqcreateevt", true);
+							 	$.event.trigger("create", {}, elem);
+							}
+						}
+
+				}
+			}
+
+			return ret;
+		};
+
+		///////////////////////////////////////
+
+		return _domManip.apply( this, arguments );
 	};
-	
+
 	// deal with the remaining 1% (html method)
-	$.fn.html = function( value ){
-		
+	$.fn.html = function( value )
+	{
+
 		// if no create events are bound, html() is being called as a setter,
 		// or the value is a function, fire the original and peace out.  only string values use innerHTML;
-		// function values use append() which is covered by $.fn.domManip 
+		// function values use append() which is covered by $.fn.domManip
 		if( !selectors.length || $.isFunction(value) || typeof value === "undefined" || !value.length ){
 			return _html.apply( this, arguments );
 		}
-		
-		// make value an array
-		arguments[0] = [value];
-		return logic.call( this, _html, arguments );
-	};
-	
-	function logic( method, args ){
-		var node, nodes = args[0], html = $(), numSelectors = selectors.length, matches = [];
-		
-		// crawl through the html structure passed in looking for matching elements.
-		for( var i=0, len=nodes.length; i<len; i++ ){
-			// make sure we're only attempting to handle objects that jquery will treat
-			// as element references
-			if (
-				typeof nodes[i] == 'object' ||
-				(
-					typeof nodes[i] == 'string' &&
-					/</.test(nodes[i]) === true
-				)
-			) {
-				node = $(nodes[i]);
-			
-				if( !node.length ){
-					continue;
-				}
-			
-				(function walk( element ){
-					element = element || node[0].parentNode;
-					var cur = (element ? element.firstChild : node[0]);
-				
-					while(cur !== null){
-						for( var x=0; x<numSelectors; x++ ){
-							if( $(cur).is(selectors[x]) ){
-								if( !cur.id ){
-									cur.id = "jqcreateevt"+(++guid);
-									gen.push(cur.id); // remember that this ID was generated
-								}
-							
-								// remember this match
-								matches.push(cur.id);
-							}
-						}
-				
-						walk( cur );
-						cur = cur.nextSibling;
-					}
-				})();
-			
-				// the html we started with, but with ids attached to elements
-				// bound with create.
-				html = html.add( node );
-			}
-			// if we can't create an element create a text node
-			else {
-				html = document.createTextNode(nodes[i]);
-			}
-		}
-		
-		// overwrite the passed in html with the new html
-		args[0] = html;
 
-		// inject elems into DOM
-		var ret = method.apply(this, args);
-		
-		// for elements with a create event...
-		$.each(matches, function(i,id){
-			var elem = document.getElementById( id );
-			
-			if( elem ){
-				// cleanup generated IDs
-				if( $.inArray(id, gen) !== -1 ){
-					elem.removeAttribute("id");
-				}
-			
-				// double check to make sure the event hasn't already fired.
-				// can happen with wrap()
-				if( !$.data( elem, "jqcreateevt") ){
-				 	$.event.trigger("create", {}, elem);
-					$.data(elem, "jqcreateevt", true);
-				}
-			}
-		});
-		
-		return ret;
-	}
-	
+		// me salto el paso de intentar usar innerHTML... por lo que saltara el domanip
+		//console.log("saltando innerHTML:",value);
+		this.empty().append( value );
+		return this;
+
+	};
+
+
 })(jQuery, jQuery.fn.domManip, jQuery.fn.html);

--- a/jquery.create.js
+++ b/jquery.create.js
@@ -2,7 +2,7 @@
 // that was updated to support text nodes by hans oksendahl (hansoksendahl.com)
 // http://www.erichynds.com/jquery/jquery-create-event/
 // full rewrite by Emilio Llamas (yumok@yahoo.com)
-// version 1.5 - 5/10/2011
+// version 1.5.1 - 7/11/2011
 
 (function($, _domManip, _html){
 	var selectors = [], gen = [], guid = 0, old = {};
@@ -28,38 +28,52 @@
 	// puede llamarse sobre los elementos creados con .innerHTML o otros metodos externos a jquery
 	$.fn.triggerCreateEvent = function ()
 	{
-		var $elem = this;
-
-		var numSelectors = selectors.length;
-//			console.log("checking selectors");
-		for( var x=0; x<numSelectors; x++ )
+		this.each(function()
 		{
-//					console.log("checking selector:",selectors[x],elem);
-			if( $elem.is(selectors[x]) )
+			var elem = this;
+			var $elem = $(this);
+
+			var numSelectors = selectors.length;
+//			console.log("checking selectors");
+			for( var x=0; x<numSelectors; x++ )
 			{
-				// double check to make sure the event hasn't already fired.
-				// can happen with wrap()
-				if( !$.data( $elem, "jqcreateevt") )
+				//console.log("checking selector:",selectors[x],$elem);
+
+				if( $elem.is(selectors[x]) )
 				{
-					$.data($elem, "jqcreateevt", true);
-				 	$.event.trigger("create", {}, $elem);
+					// double check to make sure the event hasn't already fired.
+					// can happen with wrap()
+					if( !$.data( elem, "jqcreateevt") )
+					{
+//						console.log("trigger-create:",selectors[x],elem);
+						$.data(elem, "jqcreateevt", true);
+					 	$.event.trigger("create", {}, elem);
+					}
+					else
+					{
+//						console.log("had-triggered-create:",selectors[x],elem);
+					}
 				}
+
+				$elem.find(selectors[x]).each(function()
+				{
+					// double check to make sure the event hasn't already fired.
+					// can happen with wrap()
+					if( !$.data( this, "jqcreateevt") )
+					{
+//						console.log("trigger-create(inner):",selectors[x],this);
+						$.data(this, "jqcreateevt", true);
+					 	$.event.trigger("create", {}, this);
+					}
+					else
+					{
+//						console.log("had-triggered-create(inner):",selectors[x],this);
+					}
+
+				});
+
 			}
-
-			$elem.find(selectors[x]).each(function()
-			{
-				// double check to make sure the event hasn't already fired.
-				// can happen with wrap()
-				if( !$.data( this, "jqcreateevt") )
-				{
-					$.data(this, "jqcreateevt", true);
-				 	$.event.trigger("create", {}, this);
-				}
-
-			});
-
-		}
-
+		});
 	}
 
 	// deal with 99% of DOM manip methods
@@ -84,37 +98,6 @@
 
 			$(elem).triggerCreateEvent();
 
-/*
-			var numSelectors = selectors.length;
-//			console.log("checking selectors");
-			for( var x=0; x<numSelectors; x++ )
-			{
-//					console.log("checking selector:",selectors[x],elem);
-					if( $(elem).is(selectors[x]) )
-					{
-						// double check to make sure the event hasn't already fired.
-						// can happen with wrap()
-						if( !$.data( elem, "jqcreateevt") )
-						{
-							$.data(elem, "jqcreateevt", true);
-						 	$.event.trigger("create", {}, elem);
-						}
-					}
-
-					$(elem).find(selectors[x]).each(function()
-					{
-						// double check to make sure the event hasn't already fired.
-						// can happen with wrap()
-						if( !$.data( this, "jqcreateevt") )
-						{
-							$.data(this, "jqcreateevt", true);
-						 	$.event.trigger("create", {}, this);
-						}
-
-					});
-
-			}
-*/
 
 			return ret;
 		};
@@ -131,10 +114,13 @@
 		// if no create events are bound, html() is being called as a setter,
 		// or the value is a function, fire the original and peace out.  only string values use innerHTML;
 		// function values use append() which is covered by $.fn.domManip
-		if( !selectors.length || $.isFunction(value) || typeof value === "undefined" || !value.length ){
+		if( typeof value != "string"  && (!selectors.length || $.isFunction(value) || typeof value === "undefined" || !value.length ))
+		{
+			//console.log("original.html():",value)
 			return _html.apply( this, arguments );
 		}
 
+		//console.log("innerHTMLcase.html():",value)
 		// me salto el paso de intentar usar innerHTML... por lo que saltara el domanip
 		//console.log("saltando innerHTML:",value);
 		this.empty().append( value );


### PR DESCRIPTION
Changed logic to support every kind of node (even textNodes with &amp;euro; or whatever)
What it does is duck punch the domManip callback, so it calls first the event (if the node matches any selector)
Also duck punchs the .html() method to call .append() when original would use innerHTML

My native language is Spanish, so sorry if there are errors in my english (and for the comments in spanish)
